### PR TITLE
Set background to light pink

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
             align-items: center;
             justify-content: center;
             font-family: 'Times New Roman', Times, serif;
-            background: white;
+            background: #fdf2f8;
             color: black;
         }
         h1 {

--- a/roses.html
+++ b/roses.html
@@ -12,7 +12,7 @@
     gtag('config', 'G-32H67JBWDE');
     </script>
     <style>
-        body { margin: 0; background: #ffffff; }
+        body { margin: 0; background: #fdf2f8; }
         canvas { display: block; }
         #mathExplanation {
             position: fixed;
@@ -88,7 +88,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script>
         const scene = new THREE.Scene();
-        scene.background = new THREE.Color(0xffffff);
+        scene.background = new THREE.Color(0xfdf2f8);
         const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
         const renderer = new THREE.WebGLRenderer({ antialias: true });
         renderer.setSize(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
Set page and Three.js scene backgrounds to a light pink shade (`#fdf2f8`) for improved aesthetics.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-e537ea17-37fc-4f11-acc2-e36978736d4a) · [Cursor](https://cursor.com/background-agent?bcId=bc-e537ea17-37fc-4f11-acc2-e36978736d4a)